### PR TITLE
fix: missing debug distribution libs on windows

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: bc5fcec
+_commit: 909a3bf
 _src_path: .
 author_email: 'msclock@126.com
 

--- a/cmake/OSInstall.cmake
+++ b/cmake/OSInstall.cmake
@@ -52,9 +52,11 @@ function(install_local_dependencies)
     set(arg_DESTINATION "\${CMAKE_INSTALL_PREFIX}/${arg_DESTINATION}")
   endif()
 
-  list(APPEND arg_POST_INCLUDE_REGEXES "")
   list(APPEND arg_PRE_EXCLUDE_REGEXES "")
   list(APPEND arg_POST_EXCLUDE_REGEXES "")
+  if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    list(APPEND arg_POST_INCLUDE_REGEXES ".*d.dll")
+  endif()
   if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
     list(
       APPEND

--- a/template/cmake/OSInstall.cmake
+++ b/template/cmake/OSInstall.cmake
@@ -52,9 +52,11 @@ function(install_local_dependencies)
     set(arg_DESTINATION "\${CMAKE_INSTALL_PREFIX}/${arg_DESTINATION}")
   endif()
 
-  list(APPEND arg_POST_INCLUDE_REGEXES "")
   list(APPEND arg_PRE_EXCLUDE_REGEXES "")
   list(APPEND arg_POST_EXCLUDE_REGEXES "")
+  if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    list(APPEND arg_POST_INCLUDE_REGEXES ".*d.dll")
+  endif()
   if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
     list(
       APPEND


### PR DESCRIPTION
fix the debug distribution libs, such as msvcp140d.dll, vcruntime140d.dll, are reported as missing

Close #7